### PR TITLE
Regexdomains

### DIFF
--- a/CertSlayer/CertSlayer.py
+++ b/CertSlayer/CertSlayer.py
@@ -22,15 +22,13 @@ class CertSlayer(object):
 
     def main(self):
         parser = optparse.OptionParser()
-        parser.add_option("-d", "--domains", dest="domains_arg",
-                          help="Set a list of comma-separated domains")
+        parser.add_option("-d", "--domain", dest="domains_arg", action="append",
+                          help="Domain to be monitored, might be used multiple times and supports regular expressions")
         parser.add_option("-v", "--verbose", dest="verbose_arg", default=False,
                           action="store_true", help="Verbose mode")
         (options, args) = parser.parse_args()
-        if not options.domains_arg:   # if domains_arg is not given
+        if not options.domains_arg or len(options.domains_arg) <1:   # if domains_arg is not given
             parser.error('Domain not given')
-
-        domain_list = options.domains_arg.split(",")
 
         Configuration().fake_server_address = ("127.0.0.1", 0)
         Configuration().verbose_mode = options.verbose_arg
@@ -44,7 +42,7 @@ class CertSlayer(object):
                                          CertificateExpired,
                                          CertificateNotYetValid
                                          ]
-        TestController.set_monitored_domains(domain_list)
+        TestController.set_monitored_domains(options.domains_arg)
         proxy = ProxyServer(proxy_handler=ProxyHandlerCertificateTest)
         proxy.start()
 

--- a/CertSlayer/ProxyServer.py
+++ b/CertSlayer/ProxyServer.py
@@ -290,10 +290,8 @@ class ProxyHandlerCertificateTest(ProxyHandler):
 
         self.current_destination = self.get_destination_from_data()
 
-        for domain in TestController.get_monitored_domains():
-            if domain == self.current_destination.host:
-                self.redirect_destination()
-                break
+        if TestController.match_monitored_domains(self.current_destination.host):
+            self.redirect_destination()
 
         # Else Reply 200 Connection Established and forward data
         self.send_data(socket_to=self.request, data="HTTP/1.0 200 Connection established\r\n\r\n")

--- a/CertSlayer/TestController.py
+++ b/CertSlayer/TestController.py
@@ -5,6 +5,8 @@ from CertManager import CertManager
 from FakeTLSServer import WebServerSetup
 import threading
 import os
+import re
+
 
 class TestControllerException(Exception):
     pass
@@ -44,6 +46,17 @@ class TestController(object):
     @classmethod
     def get_monitored_domains(cls):
         return cls.__monitored_domains
+
+    @classmethod
+    def match_monitored_domains(cls, domain):
+        for monitored_domain in cls.__monitored_domains:
+            try:
+                if re.match(monitored_domain, domain):
+                    return True
+            except re.error:
+                if domain == monitored_domain:
+                    return True
+        return False
 
     def __init__(self, client_address, hostname, port, testcase_list):
         self.client_address = client_address

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Usage: CertSlayer.py [options]
 
 Options:
   -h, --help            show this help message and exit
-  -d DOMAINS_ARG, --domains=DOMAINS_ARG   Set a list of comma-separated domains
+  -d DOMAINS_ARG, --domain=DOMAINS_ARG
+                        Domain to be monitored, might be used multiple times
+                        and supports regular expressions
   -v, --verbose         Verbose mode
 ```
 


### PR DESCRIPTION
Domains can be regular expressions (allows using for example: "-d .*.google.com").
Domain argument can be used multiple times, to avoid having to use "," as delimiter.
