### PR TITLE
Recognize Ctrl-C and kill server between test cases

### DIFF
--- a/CertSlayer/ProxyServer.py
+++ b/CertSlayer/ProxyServer.py
@@ -313,7 +313,12 @@ class ProxyServer(object):
 
     def start(self):
         server = ProxyThreadedServer(self.server_address, self.proxy_handler)
-        server.serve_forever()
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            server.server_close()
         #proxy = threading.Thread(target=server.serve_forever)
         #proxy.setDaemon(True)
         #proxy.start()

--- a/CertSlayer/StandaloneServer.py
+++ b/CertSlayer/StandaloneServer.py
@@ -1,4 +1,5 @@
 import time
+import sys
 from Logger import Logger
 from StandaloneModeTestController import TestStandaloneModeController
 from Configuration import Configuration
@@ -21,6 +22,11 @@ class StandaloneServer(object):
             address, port = server_address
             if Configuration().verbose_mode:
                 print "+ Web Server for host listening at %s on port %d" % (address, port)
-            raw_input(">> Hit enter for setting the next TestCase")
+            try:
+                raw_input(">> Hit enter for setting the next TestCase")
+            except KeyboardInterrupt:
+                print "" # make sure prompt is on new line
+                test_controller.cleanup()
+                sys.exit(0)
             print "+ Killing previous server"
             test_controller.cleanup()


### PR DESCRIPTION
This pull request adds handling for Ctrl-C (KeyboardInterrupt) in both modes and ensures that the server is shut down between test cases in standalone mode.